### PR TITLE
Fix permission error,  when mount host directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,12 @@ ENV JAVA_HOME /usr/java/jdk1.8.0_92
 # Download and unpack soapui
 ##########################################################
 
-RUN groupadd -r soapui && useradd -r -g soapui -m -d /home/soapui soapui
+RUN groupadd -r -g 1000 soapui && useradd -r -u 1000 -g soapui -m -d /home/soapui soapui
 
-RUN yum -y install wget && yum -y install tar && \
-    wget --no-check-certificate --no-cookies http://cdn01.downloads.smartbear.com/soapui/5.2.1/SoapUI-5.2.1-linux-bin.tar.gz && \
+RUN curl -kLO http://cdn01.downloads.smartbear.com/soapui/5.2.1/SoapUI-5.2.1-linux-bin.tar.gz && \
     echo "ba51c369cee1014319146474334fb4e1  SoapUI-5.2.1-linux-bin.tar.gz" >> MD5SUM && \
     md5sum -c MD5SUM && \
     tar -xzf SoapUI-5.2.1-linux-bin.tar.gz -C /home/soapui && \
-    yum -y remove wget && yum -y remove tar && \
     rm -f SoapUI-5.2.1-linux-bin.tar.gz MD5SUM
 
 RUN chown -R soapui:soapui /home/soapui

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,10 +59,10 @@ if [ "$1" = 'start-soapui' ]; then
 
     if [ -z "$MOCK_SERVICE_PATH" ]; then
         echo "Starting Mock-service=$MOCK_SERVICE_NAME using default mockservice url-path from SoapUI-project=$PROJECT"
-        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m $MOCK_SERVICE_NAME $PROJECT <&3 &
+        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m "$MOCK_SERVICE_NAME" $PROJECT <&3 &
     else
         echo "Starting Mock-service=$MOCK_SERVICE_NAME using url-path=$MOCK_SERVICE_PATH from SoapUI-project=$PROJECT"
-        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m $MOCK_SERVICE_NAME -a $MOCK_SERVICE_PATH $PROJECT <&3 &
+        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m "$MOCK_SERVICE_NAME" -a $MOCK_SERVICE_PATH $PROJECT <&3 &
     fi
 
 else


### PR DESCRIPTION
Hi.

I got below error messages, when mount host directory for read a SoapUI project XML file from host.
It seems to a permission problem.

```
$ sudo docker run -p 8080:8080 -ti --rm -e MOCK_SERVICE_NAME="MockServerSoapService" -v $(pwd)/soapui/:/home/soapui/soapui-prj/ -e PROJECT=/home/soapui/soapui-prj/MockServer-soapui-project.xml --privileged docker.io/fbascheper/soapui-mockservice-runner
Starting Mock-service=MockServerSoapMockService using default mockservice url-path from SoapUI-project=/home/soapui/soapui-prj/MockServer-soapui-project.xml
================================
=
= SOAPUI_HOME = /home/soapui/SoapUI-5.2.1
=
================================
SoapUI 5.2.1 MockService Runner
08:40:04,031 INFO  [DefaultSoapUICore] Creating new settings at [/home/soapui/soapui-settings.xml]
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
08:40:05,759 INFO  [PluginManager] 0 plugins loaded in 1 ms
08:40:05,759 INFO  [DefaultSoapUICore] All plugins loaded
08:40:06,303 INFO  [SoapUI] File [/home/soapui/soapui-prj/MockServer-soapui-project.xml] does not exist, trying URL instead
08:40:06,303 ERROR [SoapUI] An error occurred [no protocol: /home/soapui/soapui-prj/MockServer-soapui-project.xml], see error log for details
java.net.MalformedURLException: no protocol: /home/soapui/soapui-prj/MockServer-soapui-project.xml
  at java.net.URL.<init>(URL.java:593)
  at java.net.URL.<init>(URL.java:490)
  at java.net.URL.<init>(URL.java:439)
  at com.eviware.soapui.impl.wsdl.WsdlProject.<init>(WsdlProject.java:234)
  at com.eviware.soapui.impl.wsdl.WsdlProjectFactory.createNew(WsdlProjectFactory.java:41)
  at com.eviware.soapui.impl.wsdl.WsdlProjectFactory.createNew(WsdlProjectFactory.java:28)
  at com.eviware.soapui.tools.SoapUIMockServiceRunner.runRunner(SoapUIMockServiceRunner.java:96)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.run(AbstractSoapUIRunner.java:204)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.run(AbstractSoapUIRunner.java:139)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.runFromCommandLine(AbstractSoapUIRunner.java:114)
  at com.eviware.soapui.tools.SoapUIMockServiceRunner.main(SoapUIMockServiceRunner.java:66)
08:40:06,505 ERROR [SoapUIMockServiceRunner] java.lang.Exception: Failed to load SoapUI project file [/home/soapui/soapui-prj/MockServer-soapui-project.xml]
08:40:06,506 ERROR [SoapUI] An error occurred [Failed to load SoapUI project file [/home/soapui/soapui-prj/MockServer-soapui-project.xml]], see error log for details
java.lang.Exception: Failed to load SoapUI project file [/home/soapui/soapui-prj/MockServer-soapui-project.xml]
  at com.eviware.soapui.tools.SoapUIMockServiceRunner.runRunner(SoapUIMockServiceRunner.java:99)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.run(AbstractSoapUIRunner.java:204)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.run(AbstractSoapUIRunner.java:139)
  at com.eviware.soapui.tools.AbstractSoapUIRunner.runFromCommandLine(AbstractSoapUIRunner.java:114)
  at com.eviware.soapui.tools.SoapUIMockServiceRunner.main(SoapUIMockServiceRunner.java:66)   
```

When Docker mounts the host directory, Docker sets the directory owner to `uid = 1000`, but the current` soapui` uid is `997`. Therefore, the above error message seems to be displayed.
I modified Dockerfile to set uid/gid explicity, and fix this issue.
Please review this pull request.

Excuse my poor English writing.

Thanks,
