### PR TITLE
Adding UTF8 encoding in the JVM parameter

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,15 +59,15 @@ if [ "$1" = 'start-soapui' ]; then
 
     if [ -z "$MOCK_SERVICE_PATH" ]; then
         echo "Starting Mock-service=$MOCK_SERVICE_NAME using default mockservice url-path from SoapUI-project=$PROJECT"
-        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m "$MOCK_SERVICE_NAME" $PROJECT <&3 &
+        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -Dfile.encoding=UTF8 -p 8080 -m "$MOCK_SERVICE_NAME" $PROJECT <&3 &
     else
         echo "Starting Mock-service=$MOCK_SERVICE_NAME using url-path=$MOCK_SERVICE_PATH from SoapUI-project=$PROJECT"
-        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m "$MOCK_SERVICE_NAME" -a $MOCK_SERVICE_PATH $PROJECT <&3 &
+        gosu soapui mockservicerunner.sh -Djava.awt.headless=true -Dfile.encoding=UTF8 -p 8080 -m "$MOCK_SERVICE_NAME" -a $MOCK_SERVICE_PATH $PROJECT <&3 &
     fi
 
 else
     echo "You can start the Mock-service manually by running"
-    echo ">>>  mockservicerunner.sh -Djava.awt.headless=true -p 8080 -m $MOCK_SERVICE_NAME $PROJECT"
+    echo ">>>  mockservicerunner.sh -Djava.awt.headless=true -Dfile.encoding=UTF8 -p 8080 -m $MOCK_SERVICE_NAME $PROJECT"
     gosu soapui "$@" <&3 &
 fi
 


### PR DESCRIPTION
Lines 62, 65 and 70, added JVM parameter -Dfile.encoding=UTF8 to make sure mock responses are encoded in UTF8 by default.