### PR TITLE
Rebuild mock testrunner on alternative base image

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,60 @@
 #######################################################################
-# Create an extensible SoapUI mock service runner image using CentOS
+# Create an extensible SoapUI mock service runner image using Alpine
 #######################################################################
 
-# Use the openjdk 8 base image
-FROM openjdk:8
+# Use the alpine base image
+FROM alpine
 
-MAINTAINER fbascheper <temp01@fam-scheper.nl>
+RUN apk update && \
+    apk upgrade 
+RUN apk add openjdk8
+
+LABEL maintainer="fbascheper <temp01@fam-scheper.nl>"
 
 ##########################################################
 # Download and unpack soapui
 ##########################################################
 
-RUN groupadd -r -g 1000 soapui && useradd -r -u 1000 -g soapui -m -d /home/soapui soapui
+RUN addgroup -S -g 1000 soapui && adduser -S -u 1000 -G soapui --disabled-password --gecos "" -h /home/soapui soapui
+
+RUN apk --no-cache add curl tar
 
 RUN curl -kLO https://s3.amazonaws.com/downloads.eviware/soapuios/5.4.0/SoapUI-5.4.0-linux-bin.tar.gz && \
-    echo "151ebe65215b19898e31ccbf5d5ad68b SoapUI-5.4.0-linux-bin.tar.gz" >> MD5SUM && \
+    echo "151ebe65215b19898e31ccbf5d5ad68b  SoapUI-5.4.0-linux-bin.tar.gz" >> MD5SUM && \
     md5sum -c MD5SUM && \
     tar -xzf SoapUI-5.4.0-linux-bin.tar.gz -C /home/soapui && \
     rm -f SoapUI-5.4.0-linux-bin.tar.gz MD5SUM
 
 RUN chown -R soapui:soapui /home/soapui
-RUN find /home/soapui -type d -execdir chmod 770 {} \;
-RUN find /home/soapui -type f -execdir chmod 660 {} \;
+RUN find /home/soapui -type d -exec chmod 770 {} \;
+RUN find /home/soapui -type f -exec chmod 660 {} \;
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cron \
-        gosu \
-    && rm -rf /var/lib/apt/lists/*
+##########################################################
+# Install Gosu (used in docker-entrypoint.sh)
+##########################################################
+ENV GOSU_VERSION 1.12
+RUN set -eux
+RUN apk add --no-cache --virtual .gosu-deps \
+        ca-certificates \
+        dpkg \
+        gnupg \
+    ; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+# verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    command -v gpgconf && gpgconf --kill all || :; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+# clean up fetch dependencies
+    apk del --no-network .gosu-deps; \
+    \
+    chmod +x /usr/local/bin/gosu;
 
 ############################################
 # Setup MockService runner
@@ -56,8 +83,8 @@ RUN chmod 700 /docker-entrypoint.sh
 RUN chmod 770 $SOAPUI_DIR/bin/*.sh
 
 RUN chown -R soapui:soapui $SOAPUI_PRJ
-RUN find $SOAPUI_PRJ -type d -execdir chmod 770 {} \;
-RUN find $SOAPUI_PRJ -type f -execdir chmod 660 {} \;
+RUN find $SOAPUI_PRJ -type d -exec chmod 770 {} \;
+RUN find $SOAPUI_PRJ -type f -exec chmod 660 {} \;
 
 
 ############################################

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # Default usage: docker-entrypoint.sh start-soapui
@@ -34,7 +34,7 @@ if [ -z "$PROJECT" ]; then
 fi
 
 if [ -z "$MOCK_SERVICE_NAME" ]; then
-    echo "Enviromentment variable MOCK_SERVICE_NAME should have been set explicitly (e.g. by  -e MOCK_SERVICE_NAME=BLZ-SOAP11-MockService"
+    echo "Environment variable MOCK_SERVICE_NAME should have been set explicitly (e.g. by  -e MOCK_SERVICE_NAME=BLZ-SOAP11-MockService"
     exit 1
 fi
 
@@ -71,10 +71,10 @@ else
     gosu soapui "$@" <&3 &
 fi
 
-# wait for mocksevicerunner to exit
+# wait for mockservicerunner to exit
 PID=$!
 wait $PID
-# prevent another trap while mocksevicerunner is stopping
+# prevent another trap while mockservicerunner is stopping
 trap - TERM INT
 # wait for stop to complete
 wait $PID


### PR DESCRIPTION
The base image in Dockerfile was set to **openjdk:8** but that image has been marked as deprecated.

I rewrote the image to be built on top of Alpine and adjusted the shell scripts to have a working testrunner.